### PR TITLE
Group region writes to reduce IO

### DIFF
--- a/pipeline/carbonpipeline/core.py
+++ b/pipeline/carbonpipeline/core.py
@@ -133,10 +133,12 @@ class CarbonPipeline:
         # Conversion to AMF predictors and intelligent chunk writing
         index = ['region_id', 'latitude', 'longitude', 'valid_time']
         print("✍️ Writing dataset chunks...", flush=True)
-        tmp_dirs = self.dataset_manager.write_chunks(all_dss, preds, index, len(rect_regions))
+        tmp_files = self.dataset_manager.write_chunks(
+            all_dss, preds, index, len(rect_regions)
+        )
 
         # Reopen the chunks for each region and create the NetCDF files
-        region_dsets = self.dataset_manager.concat_chunks(tmp_dirs)
+        region_dsets = self.dataset_manager.concat_chunks(tmp_files)
 
         # Aggregation --> not available for global option because too much data --> not optimized with chunk loading
         resample_methods = {"DAILY": "1D", "MONTHLY": "1ME"}


### PR DESCRIPTION
## Summary
- Batch multiple regions into single NetCDF files when writing chunks to reduce filesystem overhead
- Update chunk concatenation to reopen batched files and split per region
- Adjust area processing to handle new chunk-writing scheme

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1e68632e48326b13c90f1d1fce2b9